### PR TITLE
Add MD5 to SQLI patterns

### DIFF
--- a/web/sqli_probe_patterns.txt
+++ b/web/sqli_probe_patterns.txt
@@ -15,3 +15,4 @@ pg_sleep%28
 sleep%28
 upper%28
 hex%28
+md5%28


### PR DESCRIPTION
From my past experiences, [`md5()`](https://www.w3resource.com/mysql/encryption-and-compression-functions/md5().php), due to its potentially time-consuming nature, can be used to:
* Aid blind SQL injections by being able to create a detectable delay
* As part of a wider DOS attack
* Help to obfuscate values that would otherwise be filtered, escaped or trimmed during a different stage or layer, and then comparing the values with known hashes

It seems pretty safe to me to try to detect it as part of the pattern list. Let me know what you think!