### PR TITLE
Add .env to sensitive data list

### DIFF
--- a/web/sensitive_data.txt
+++ b/web/sensitive_data.txt
@@ -12,6 +12,7 @@
 .config
 .cvs
 .cvsignore
+.env
 .forward
 .git/HEAD
 .git


### PR DESCRIPTION
Certain web setups may use `.env` files to store environmental variables that are loaded during app/server startup. Those often contain passwords or secret keys. A misconfigured server could accidentally leak the file.