### PR TITLE
Add gobuster to bad_user_agents

### DIFF
--- a/web/bad_user_agents.regex.txt
+++ b/web/bad_user_agents.regex.txt
@@ -194,6 +194,7 @@
 \bGigabot\b
 \bG-i-g-a-b-o-t\b
 \bGo-Ahead-Got-It\b
+\bgobuster\b
 \bGotit\b
 \bGoZilla\b
 \bGo!Zilla\b

--- a/web/bad_user_agents.txt
+++ b/web/bad_user_agents.txt
@@ -194,6 +194,7 @@ Gigablast
 Gigabot
 G-i-g-a-b-o-t
 Go-Ahead-Got-It
+gobuster
 Gotit
 GoZilla
 Go!Zilla


### PR DESCRIPTION
Gobuster is a tool like dirbuster but was missing.
The user-agent is `gobuster 2.0.1` (old version, newest is 3.1.0) but that does not matter.