### PR TITLE
fix: Remove MicroMessenger from bad_user_agents.txt

### DIFF
--- a/web/bad_user_agents.regex.txt
+++ b/web/bad_user_agents.regex.txt
@@ -309,7 +309,6 @@
 \bMegaIndex.ru\b
 \bMetauri\b
 \bMFC_Tear_Sample\b
-\bMicroMessenger\b
 \bMicrosoft\ Data\ Access\b
 \bMicrosoft\ URL\ Control\b
 \bMIDown\ tool\b

--- a/web/bad_user_agents.txt
+++ b/web/bad_user_agents.txt
@@ -309,7 +309,6 @@ mediawords
 MegaIndex.ru
 Metauri
 MFC_Tear_Sample
-MicroMessenger
 Microsoft\ Data\ Access
 Microsoft\ URL\ Control
 MIDown\ tool


### PR DESCRIPTION
fixes #44
MicroMessenger is the UA of WeChat chat software, definitely not a bad UA.