### PR TITLE
Add Bytespider to bad user agents

### DIFF
--- a/web/bad_user_agents.regex.txt
+++ b/web/bad_user_agents.regex.txt
@@ -86,6 +86,7 @@
 \bBullseye\b
 \bBunnySlippers\b
 \bBuzzSumo\b
+\bBytespider\b
 \bCalculon\b
 \bCATExplorador\b
 \bCazoodleBot\b


### PR DESCRIPTION
Crawling bot that doesn't respect the robots.txt rules and continues to make requests even on overloaded servers.

Makes requests through Amazon AWS or Bytedance owned network.