### PR TITLE
fix(rdns_seo_bots): change rdns associated with qwantbot

### DIFF
--- a/whitelists/benign_bots/search_engine_crawlers/rdns_seo_bots.txt
+++ b/whitelists/benign_bots/search_engine_crawlers/rdns_seo_bots.txt
@@ -6,7 +6,7 @@
 .crawl.baidu.com.
 .crawl.baidu.jp.
 .crawl.yahoo.net.
-.search.qwant.com.
+.qwant.com.
 .babbar.eu.
 .crawl.amazonbot.amazon.
 .crawl.sogou.com.


### PR DESCRIPTION
# Bad rdns configuration to resolve qwantbot
As mentioned here: https://help.qwant.com/bot/#elementor-toc__heading-anchor-4, qwant indicates : 
>To check if a web crawler accessing your server is from Qwant, perform a reverse DNS lookup and verify that it resolves to a name ending with “qwant.com”.

Multiple False positive appears with https://app.crowdsec.net/hub/author/crowdsecurity/postoverflows/seo-bots-whitelist : 
Examples : 
- https://app.crowdsec.net/cti/91.242.162.5
- https://app.crowdsec.net/cti/91.242.162.10
- https://app.crowdsec.net/cti/91.242.162.6
- CIDR : 91.242.162.0/24 (https://help.qwant.com/wp-content/uploads/sites/2/2025/01/qwantbot.json)

