### PR TITLE
Fix: Remove redundant word boundaries in '404enemy' regex pattern to prevent false positives.

### DIFF
--- a/web/bad_user_agents.regex.txt
+++ b/web/bad_user_agents.regex.txt
@@ -23,7 +23,7 @@
 #
 \b360Spider\b
 \b404checker\b
-\b\b404enemy\b\b
+\b404enemy\b
 \b80legs\b
 \bAbonti\b
 \bAboundex\b


### PR DESCRIPTION
### Problem

In CrowdSec v1.6.8, we experienced unexpected false positives from the `crowdsecurity/http-bad-user-agent` scenario. Legitimate user-agents, including recent Android mobile browsers, were incorrectly matched by the `404enemy` regex in `bad_user_agents.regex.txt`.

### Root Cause

The problematic line was:

```
\b\b404enemy\b\b
```

This pattern contains *consecutive* word boundary assertions (`\b\b`) on both sides of `404enemy`. While this does not affect matching behavior in some regex engines, the [RE2 regex engine](https://github.com/google/re2) (used by CrowdSec, as it is the default regex backend in Go) does not optimize away redundant word boundaries. Instead, in certain edge cases, this can lead to matches in places the author did not intend—including every position in a user-agent string—causing mass false positives.

### Solution

This pull request updates the pattern to:

```
\b404enemy\b
```

- This ensures that only occurrences of the literal word "404enemy" are matched, with proper word boundaries.
- It eliminates the risk of unwanted matches due to compounded zero-width assertions.
- The update preserves the intent of the blocklist, targeting only bots with the "404enemy" identifier in their user-agent.

### Technical Notes

- **Regex context**: According to [RE2 documentation](https://github.com/google/re2/wiki/Syntax), multiple consecutive word boundaries do not enhance pattern specificity and should be avoided.
- **Backward compatibility**: This change does not reduce protection; it only removes a misconfiguration.
- **Prior experience**: On previous versions of CrowdSec (prior to v1.6.8), we had no such issues, suggesting this is a regression related to recent regex list changes or differences in engine strictness.

### Testing

- Reproduced the false positive with the original pattern and a standard mobile browser user-agent.
- Verified that, after the change, only real "404enemy" bots are matched, and legitimate browsers are unaffected.
